### PR TITLE
Airport import should not store duplicate airports.

### DIFF
--- a/lib/import/airports.js
+++ b/lib/import/airports.js
@@ -37,21 +37,33 @@ function read_jsonfile(geojson, verbose) {
 function save_airports(country_code, feature_collection) {
   var airports = [];
   country_code = country_code.toLowerCase();
-
+  // For duplicate checking
+  var seen = {};
   _.map(feature_collection.features, function(feat) {
     feat.properties.country_code = feat.properties.country_code.toLowerCase();
     if (country_code && feat.properties.country_code !== country_code) {
       // if a country code is specified, filter airports
       return;
     }
-    airports.push(new Airport({
+
+    var airport = {
       country_code: feat.properties.country_code,
       admin_code: feat.properties.adm2_code,
       name: feat.properties.name,
       fcode: feat.properties.fcode,
       airport_code: feat.properties.iata_code.toLowerCase(),
       geo: feat.geometry.coordinates
-    }));
+    };
+
+    // Add or increase value of airport for later duplicate catching
+    seen[
+      JSON.stringify(airport)
+    ] = seen[JSON.stringify(airport)] ? seen[JSON.stringify(airport)] + 1 : 1;
+
+    if (seen[JSON.stringify(airport)] === 1) {
+      // Add airport to array if not seen yet
+      airports.push(new Airport(airport));
+    }
   });
 
   return new Promise(function(resolve, reject) {
@@ -60,6 +72,7 @@ function save_airports(country_code, feature_collection) {
       if (err) {
         return reject(err);
       }
+
       Airport.insertMany(airports, function(err) {
         if (err) {
           return reject(err);

--- a/test/data/geojson/airports.json
+++ b/test/data/geojson/airports.json
@@ -53,6 +53,59 @@
         "gtopo30":838,
         "wac_name":"Brazil"
       }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Feature",
+        "coordinates": [-45.9995565,-22.240378]
+      },
+      "properties": {
+        "faa_code":"",
+        "fclass":"P",
+        "adm2_code":3152501,
+        "wiki_link":"http://en.wikipedia.org/wiki/Pouso_Alegre",
+        "adm1_code":15,
+        "envelope_id":"",
+        "country_name":"Brazil",
+        "adm1_name_ascii":"Minas Gerais",
+        "asciiname":"Pouso Alegre",
+        "cc2":"",
+        "is_geonames":"Y",
+        "gmt_offset":-2.0,
+        "adm2_name_ascii":"Pouso Alegre",
+        "country_code":"BR",
+        "city_code_list":"PPY",
+        "geoname_id":3452525,
+        "wac":316,
+        "continent_name":"South America",
+        "city_detail_list":"PPY|3452525|Pouso Alegre|Pouso Alegre",
+        "adm2_name_utf":"Pouso Alegre",
+        "iata_code":"PPY",
+        "tvl_por_list":"PPY",
+        "date_until":"",
+        "city_name_list":"Pouso Alegre",
+        "state_code":"MG",
+        "population":115201,
+        "location_type":"C",
+        "timezone":"America/Sao_Paulo",
+        "adm1_name_utf":"Minas Gerais",
+        "icao_code":"",
+        "raw_offset":-3.0,
+        "dst_offset":-3.0,
+        "page_rank":"",
+        "adm3_code":"",
+        "alt_name_section":"ru|Позу-Алегри|=bg|Пузу Алегри|=bpy|পাউসো আলেগ্রে|=kk|Позу-Алегри|=th|โปซูอาเลกรี|=zh|波苏阿莱格里|",
+        "comment":"",
+        "date_from":"",
+        "name":"Pouso Alegre",
+        "moddate":"2012-08-03",
+        "elevation":"",
+        "fcode":"PPL",
+        "adm4_code":"",
+        "gtopo30":838,
+        "wac_name":"Brazil"
+      }
     }
   ]
 }

--- a/test/importer_airport.js
+++ b/test/importer_airport.js
@@ -24,8 +24,16 @@ describe('Import airports', function() {
   });
 
   describe('Airport data stored', function() {
+    it('should not store duplicates', function() {
+      Airport.count({}, function(err, c) {
+        if (err) { console.log(err); }
+        assert.strictEqual(1, c);
+      });
+    });
+
     it('should store name', function(done) {
       var all_done = [];
+
       airport_geojson.features.forEach(function(feature) {
         var admin_code = String(feature.properties.adm2_code);
         var promise = new Promise(function(resolve) {


### PR DESCRIPTION
Nick added a unique index to the Airport model. The import script broke when running for first time on my local instance due to a duplicate airport in the json file.

This commit ensures no dupes are stored.

Problem: After removing and then re-adding the index manually, the import doesn't break when a duplicate is stored.